### PR TITLE
Add bundled ffmpeg support and update documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,8 +60,9 @@ beatboss_installer_copy.iss
 #main_test_flet.py
 #player_flet.py
 
-# Bundled VLC (large binary files, download separately)
+# Bundled VLC and ffmpeg (large binary files, download separately)
 vlc/
+ffmpeg
 
 # Build Configs (Excluded by request)
 # *.spec

--- a/README.md
+++ b/README.md
@@ -46,7 +46,11 @@ To build the executable and bundle dependencies correctly, follow these steps:
     *   Structure should be: `vlc/vlc.exe`, `vlc/plugins/`, etc.
 3.  **FFmpeg (Essential for Local Playback)**
     *   Download: [ffmpeg-master-latest-win64-gpl.zip](https://github.com/BtbN/FFmpeg-Builds/releases)
-    *   Copy `ffmpeg.exe` and all `.dll` files from the `bin/` folder to the project root.
+    *   Copy `ffmpeg.exe` and all `.dll` files from the `bin/` folder to ffmpeg folder in the parent directory, the structure can be as follows
+      ```bash
+      ../ffmpeg/bin/ffmpeg.exe
+      ../ffmpeg/ffmpeg.exe
+      ```
     *   Required DLLs include: `avcodec-*.dll`, `avformat-*.dll`, `avutil-*.dll`, `swresample-*.dll`, `swscale-*.dll`.
 
 > [!IMPORTANT]


### PR DESCRIPTION
Introduces logic to detect and use a bundled ffmpeg executable from a parent directory 'ffmpeg' folder, falling back to system ffmpeg if not found. Updates .gitignore and README.md to reflect the new expected ffmpeg directory structure and usage. Improves local file playback reliability by ensuring ffmpeg is available and correctly prioritized for audio conversion.